### PR TITLE
Update cache_control to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
 jsonwebtoken = "^7"
-cache_control = "0.1.0"
+cache_control = "0.2.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -195,7 +195,7 @@ impl Client {
             if let Ok(value) = value.to_str() {
                 if let Some(cc) = cache_control::CacheControl::from_value(value) {
                     if let Some(max_age) = cc.max_age {
-                        let seconds = max_age.num_seconds();
+                        let seconds = max_age.whole_seconds();
                         if seconds >= 0 {
                             *cache = Some(Instant::now() + Duration::from_secs(seconds as u64));
                         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -31,6 +31,7 @@ struct CertsObject {
     keys: Vec<Cert>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 struct Cert {
     kid: String,
@@ -195,10 +196,8 @@ impl Client {
             if let Ok(value) = value.to_str() {
                 if let Some(cc) = cache_control::CacheControl::from_value(value) {
                     if let Some(max_age) = cc.max_age {
-                        let seconds = max_age.whole_seconds();
-                        if seconds >= 0 {
-                            *cache = Some(Instant::now() + Duration::from_secs(seconds as u64));
-                        }
+                        let seconds = max_age.as_secs();
+                        *cache = Some(Instant::now() + Duration::from_secs(seconds as u64));
                     }
                 }
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
-use std::{self, fmt, io};
 use hyper;
 use serde_json;
+use std::{self, fmt, io};
 
 /// A network or validation error
 #[derive(Debug)]
@@ -35,7 +35,9 @@ impl fmt::Display for Error {
             Error::InvalidToken => f.write_str("Token was not recognized by google"),
             Error::InvalidIssuer => f.write_str("Token was not issued by google"),
             Error::InvalidAudience => f.write_str("Token is for a different google application"),
-            Error::InvalidHostedDomain => f.write_str("User is not a member of the hosted domain(s)"),
+            Error::InvalidHostedDomain => {
+                f.write_str("User is not a member of the hosted domain(s)")
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,10 @@
 //! ```
 
 extern crate hyper;
-#[cfg(feature = "with-rustls")]
-extern crate hyper_rustls;
 #[cfg(feature = "with-openssl")]
 extern crate hyper_openssl;
+#[cfg(feature = "with-rustls")]
+extern crate hyper_rustls;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
@@ -54,8 +54,8 @@ mod client;
 mod error;
 mod token;
 
-pub use client::Client;
 pub use client::CachedCerts;
+pub use client::Client;
 pub use error::Error;
 pub use token::IdInfo;
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -2,7 +2,7 @@ use crate::client::Client;
 use crate::error::Error;
 
 #[derive(Debug, Deserialize)]
-pub struct IdInfo<EF=bool, TM=u64> {
+pub struct IdInfo<EF = bool, TM = u64> {
     /// These six fields are included in all Google ID Tokens.
     pub iss: String,
     pub sub: String,
@@ -17,7 +17,7 @@ pub struct IdInfo<EF=bool, TM=u64> {
     /// These seven fields are only included when the user has granted the "profile" and
     /// "email" OAuth scopes to the application.
     pub email: Option<String>,
-    pub email_verified: Option<EF>,  // eg. "true" (but unusually as a string)
+    pub email_verified: Option<EF>, // eg. "true" (but unusually as a string)
     pub name: Option<String>,
     pub picture: Option<String>,
     pub given_name: Option<String>,
@@ -33,7 +33,9 @@ impl IdInfo {
         // Check the id was authorized by google
         match self.iss.as_str() {
             "accounts.google.com" | "https://accounts.google.com" => {}
-            _ => { return Err(Error::InvalidIssuer); }
+            _ => {
+                return Err(Error::InvalidIssuer);
+            }
         }
 
         // Check the token belongs to the application(s)
@@ -45,7 +47,9 @@ impl IdInfo {
         if client.hosted_domains.len() > 0 {
             match self.hd {
                 Some(ref domain) if client.hosted_domains.contains(domain) => {}
-                _ => { return Err(Error::InvalidHostedDomain); }
+                _ => {
+                    return Err(Error::InvalidHostedDomain);
+                }
             }
         }
 


### PR DESCRIPTION
Version 0.1.0 of cache_control has a dependency on an old version of the time crate that does not compile on rust versions >=1.80.0. I also ran `cargo fmt`.